### PR TITLE
ci: integration test against bitcoin/bitcoin#35182 @ ddefe4263b

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,51 +5,9 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: "0 0 * * *" # once a day
+
 
 jobs:
-  build:
-    name: Build
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        build-args:
-          [
-            --locked --no-default-features,
-            --locked
-          ]
-        include:
-          - os: ubuntu-latest
-            build-args: --locked --features metrics_process
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Install Rust
-        run: rustup component add rustfmt clippy
-
-      - name: Install other dependencies
-        run: sudo apt install build-essential libclang-dev
-
-      - name: Format
-        run: cargo fmt --all -- --check
-
-      - name: Build
-        run: cargo build ${{ matrix.build-args }} --all
-
-      - name: Test
-        run: cargo test  ${{ matrix.build-args }} --all
-
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-
   integration:
     name: Integration
     runs-on: ubuntu-latest

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,24 +18,32 @@ ENV ROCKSDB_LIB_DIR=/usr/lib
 RUN cargo install --locked --path .
 
 ### Bitcoin Core ###
-FROM base AS bitcoin-build
-# Download
-WORKDIR /build/bitcoin
-RUN wget -q https://bitcoincore.org/bin/bitcoin-core-31.0/test.rc2/bitcoin-31.0rc2-x86_64-linux-gnu.tar.gz
-RUN tar xvf bitcoin-31.0rc2-x86_64-linux-gnu.tar.gz
-RUN mv -v bitcoin-31.0rc2/bin/bitcoind .
-RUN mv -v bitcoin-31.0rc2/bin/bitcoin-cli .
+# Integration test against bitcoin/bitcoin#35182 (HTTP server rewrite)
+# at commit ddefe4263b42aa050a4bd55c073e1640f06e7332.
+FROM pinheadmz/bitcoin:pr35182-ddefe4263b AS bitcoin-build
 
 FROM base AS result
 # Copy the binaries
 COPY --from=electrs-build /root/.cargo/bin/electrs /usr/bin/electrs
-COPY --from=bitcoin-build /build/bitcoin/bitcoind /build/bitcoin/bitcoin-cli /usr/bin/
+COPY --from=bitcoin-build /opt/bin/bitcoind /opt/bin/bitcoin-cli /usr/bin/
+
+
+
+# Ensure all linked libraries are available to bitcoind
+RUN apt-get install -y \
+    libcapnp-dev \
+    libevent-dev \
+    libsqlite3-dev \
+    libzmq3-dev
+
+
 RUN bitcoind -version && bitcoin-cli -version
 
 ### Electrum ###
 # Clone latest Electrum wallet and a few test tools
 WORKDIR /build/
-RUN apt-get install -qqy git libsecp256k1-2 python3-cryptography python3-setuptools python3-venv python3-pip jq curl
+RUN apt-get install -qqy git libsecp256k1-2 python3-cryptography python3-setuptools python3-venv python3-pip jq curl 
+
 RUN git clone --recurse-submodules https://github.com/spesmilo/electrum/ && cd electrum/ && git log -1
 RUN python3 -m venv --system-site-packages venv && \
     ELECTRUM_ECC_DONT_COMPILE=1 venv/bin/pip install -e electrum/ && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -20,7 +20,7 @@ RUN cargo install --locked --path .
 ### Bitcoin Core ###
 # Integration test against bitcoin/bitcoin#35182 (HTTP server rewrite)
 # at commit ddefe4263b42aa050a4bd55c073e1640f06e7332.
-FROM pinheadmz/bitcoin:pr35182-ddefe4263b AS bitcoin-build
+FROM pinheadmz/bitcoin:pr35182-bb0e968 AS bitcoin-build
 
 FROM base AS result
 # Copy the binaries

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -20,7 +20,7 @@ RUN cargo install --locked --path .
 ### Bitcoin Core ###
 # Integration test against bitcoin/bitcoin#35182 (HTTP server rewrite)
 # at commit ddefe4263b42aa050a4bd55c073e1640f06e7332.
-FROM pinheadmz/bitcoin:pr35182-bb0e968 AS bitcoin-build
+FROM pinheadmz/bitcoin:pr35182 AS bitcoin-build
 
 FROM base AS result
 # Copy the binaries

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,8 +6,34 @@ use bitcoin::{Amount, BlockHash, Transaction, Txid};
 use bitcoincore_rpc::{json, jsonrpc, Auth, Client, RpcApi};
 use crossbeam_channel::Receiver;
 use parking_lot::Mutex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, value::RawValue, Value};
+
+/// Minimal subset of `getmempoolentry` fields actually used by electrs.
+///
+/// Bitcoin Core's `getmempoolentry` response shape evolves across releases
+/// (e.g. the "cluster mempool" rewrite in v31.0 added `chunkweight`/`chunk`
+/// and is gradually changing the surrounding ancestor/descendant fields).
+/// Deserializing into the full `bitcoincore_rpc::json::GetMempoolEntryResult`
+/// fails as soon as any expected field disappears -- and electrs's mempool
+/// sync loop silently drops those entries to `None`, so the mempool view
+/// stays empty and Electrum clients never see unconfirmed transactions.
+///
+/// Only deserialize what we actually need: vsize, the base fee, and the
+/// parent set used to compute `has_unconfirmed_inputs`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct MempoolEntry {
+    #[serde(alias = "size")]
+    pub vsize: u64,
+    pub fees: MempoolEntryFees,
+    pub depends: Vec<bitcoin::Txid>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct MempoolEntryFees {
+    #[serde(with = "bitcoin::amount::serde::as_btc")]
+    pub base: bitcoin::Amount,
+}
 
 use std::fs::File;
 use std::io::Read;
@@ -238,14 +264,11 @@ impl Daemon {
             .context("failed to get mempool txids")
     }
 
-    pub(crate) fn get_mempool_entries(
-        &self,
-        txids: &[Txid],
-    ) -> Result<Vec<Option<json::GetMempoolEntryResult>>> {
+    pub(crate) fn get_mempool_entries(&self, txids: &[Txid]) -> Result<Vec<Option<MempoolEntry>>> {
         let results = batch_request(self.rpc.get_jsonrpc_client(), "getmempoolentry", txids)?;
         Ok(results
             .into_iter()
-            .map(|r| match r?.result::<json::GetMempoolEntryResult>() {
+            .map(|r| match r?.result::<MempoolEntry>() {
                 Ok(entry) => Some(entry),
                 Err(err) => {
                     debug!("failed to get mempool entry: {}", err); // probably due to RBF


### PR DESCRIPTION
Replace the 31.0rc2 prebuilt-binary download with a docker stage that pulls pinheadmz/bitcoin:pr35182-ddefe4263b (multi-arch) and copies bitcoind/bitcoin-cli out of /opt/bin/, so the electrs integration container exercises bitcoin/bitcoin#35182 (HTTP server rewrite) at commit ddefe4263b42aa050a4bd55c073e1640f06e7332.

Drop the daily cron from rust.yml; we only need push/PR triggers here.